### PR TITLE
Minor rewording

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -79,7 +79,7 @@ Your applications run isolated from each other on your microcontrollers.
 
 ###### Secure communications
 
-You communicate with our cloud through our API, we take care of the rest.
+You communicate with our cloud through a simple API, we take care of the rest.
 
   </HighLight>
 </HighLights>


### PR DESCRIPTION
Avoids to use "own" twice within 5 words.