### PR TITLE
Cleanup footer

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -10,6 +10,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
+    paddingTop: theme.spacing(2),
     paddingBottom: theme.spacing(6),
   },
   logo: {
@@ -27,19 +28,13 @@ export default function Footer(): JSX.Element {
       <div className={classes.container}>
         <Breadcrumbs aria-label="breadcrumb" separator="|">
           <Link to="/terms-of-service">
-            <Typography variant="body2" component="span">
-              Terms of Service
-            </Typography>
+            <Typography variant="body2">Terms of Service</Typography>
           </Link>
           <Link to="/privacy-policy">
-            <Typography variant="body2" component="span">
-              Privacy policy
-            </Typography>
+            <Typography variant="body2">Privacy policy</Typography>
           </Link>
           <Link to="/cookies-policy">
-            <Typography variant="body2" component="span">
-              Cookies policy
-            </Typography>
+            <Typography variant="body2">Cookies policy</Typography>
           </Link>
         </Breadcrumbs>
         <Logo className={classes.logo} />


### PR DESCRIPTION
I simplified the footer. There are two reasons I wanted to do this:

1. There was a big "teeth gap" between the left and the right meny
2. The address is not something a typical visitor of toit.io does need, and it is available in the ToS (the first location I would look if I wanted to know the address).

To give a bit more interest to the footer, I've also added the faded logo to the footer.

Previous layout:

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/133277/107546730-f9993580-6bcc-11eb-8415-f372ab9de4a7.png">

Now:

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/133277/107546467-ade68c00-6bcc-11eb-9cda-82c05ac59644.png">
