### PR TITLE
Fix color of cookie notice

### DIFF
--- a/src/components/cookie.tsx
+++ b/src/components/cookie.tsx
@@ -4,9 +4,6 @@ import CookieConsent from "react-cookie-consent";
 
 const useStyles = makeStyles((theme: Theme) => ({
   button: {
-    "&:hover": {
-      backgroundColor: theme.palette.secondary.light,
-    },
     margin: theme.spacing(2),
   },
 }));
@@ -24,7 +21,7 @@ export default function Cookie(): JSX.Element {
       cookieName="gatsby-gdpr-google-analytics"
       disableButtonStyles
       style={{
-        background: theme.palette.primary.main,
+        background: theme.palette.background.default,
         boxShadow: "0px 0px 30px rgba(0,0,0,0.3)",
       }}
       ButtonComponent={(props: { id: string }) => (


### PR DESCRIPTION
I just realised that the cookie notice doesn't look right now that I've overhauled the theme.

<img width="782" alt="image" src="https://user-images.githubusercontent.com/133277/110451813-e04cb180-80c4-11eb-9a80-b7a48b29e834.png">

This PR fixes that.

I thought I'd just fix it quickly so we can release the new product pages