### PR TITLE
Fix issue with menu items not being highlighted

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,6 +21,7 @@ module.exports = {
       },
     },
     "gatsby-plugin-eslint",
+    "gatsby-plugin-remove-trailing-slashes",
     "gatsby-plugin-sitemap",
     "gatsby-plugin-typescript-checker",
     "gatsby-plugin-material-ui",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gatsby-plugin-manifest": "^2.11.0",
     "gatsby-plugin-material-ui": "^2.1.10",
     "gatsby-plugin-mdx": "^1.9.0",
+    "gatsby-plugin-remove-trailing-slashes": "^2.10.0",
     "gatsby-plugin-sitemap": "^2.11.0",
     "gatsby-plugin-svgr-svgo": "^1.1.0",
     "gatsby-plugin-typescript": "^2.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5915,6 +5915,13 @@ gatsby-plugin-page-creator@^2.9.0:
     globby "^11.0.1"
     lodash "^4.17.20"
 
+gatsby-plugin-remove-trailing-slashes@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-remove-trailing-slashes/-/gatsby-plugin-remove-trailing-slashes-2.10.0.tgz#dfb5a2d457a2941730ebf1d550fc7b5a0b37c471"
+  integrity sha512-8kx9wBgPJXVcxGt1lUxtfZe1XD+4SRimHnU1T/KE7qiWlSZ8qIupF9rwnjRpxJd35zHjv25Teicy3u/60EXG+A==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 gatsby-plugin-sitemap@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-2.11.0.tgz#7e7b22b20c316d1c5087dd7213e629c342231014"


### PR DESCRIPTION
As desribed in the issue, there were 2 ways to solve this. I decided to use the plugin because I don't like the `/pricing/` URLs, and they also caused issues because for some reason the `currentPath` that you get from gatsby is still `/pricing` not `/pricing/` which is strange.

Fixes #78