### PR TITLE
Add "blog" menu item

### DIFF
--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -37,7 +37,7 @@ function MenuLink({ item, isActive }: MenuLinkProps): JSX.Element {
   const classes = useStyles();
   if (item.to != undefined) {
     return (
-      <a target="_blank" rel="noreferrer" className={classes.link} href={item.to}>
+      <a className={classes.link} href={item.to}>
         {item.title}
         <PositionedExternalLinkIcon />
       </a>

--- a/src/components/popup-menu/menu.tsx
+++ b/src/components/popup-menu/menu.tsx
@@ -68,7 +68,7 @@ function MenuLink({ item }: { item: menu.MenuItem }): JSX.Element {
   const classes = useStyles();
   if (item.to != undefined) {
     return (
-      <a target="_blank" rel="noreferrer" href={item.to} className={classes.link}>
+      <a href={item.to} className={classes.link}>
         <Typography variant="body1" className={classes.typography} component="span">
           {item.title} <ExternalLinkIcon />
         </Typography>

--- a/src/content/menu.yaml
+++ b/src/content/menu.yaml
@@ -17,3 +17,6 @@ items:
   - path: /docs
     title: Docs
     to: https://docs.toit.io/
+  - path: /blog
+    title: Blog
+    to: https://blog.toit.io/


### PR DESCRIPTION
I've decided to remove the `target="_blank"` from the external menu links. [I think they shouldn't be there](https://css-tricks.com/use-target_blank/), especially since there is an icon that makes it clear that this links to another site. If you disagree I can revert that change.

Closes #82 